### PR TITLE
Add Command and Target Directory to the Actions

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,8 @@ Assets Artifacts, is designed to compile the assets of your project and commit a
 
 ## Configuration
 
-The configuration for this action is mostly hardcoded for now. The command used for compiling the assets is always `yarn build` and the target directory is always `./build`.
+- `command` Pass the command the action has to use to build the artifacts. Default to `yarn build`.
+- `target-dir` Pass the director where the action has to store the artifacts. Default to `build`.
 
 ## Workflow Example
 
@@ -51,10 +52,13 @@ jobs:
           GIT_USER: ${{ secrets.GIT_USER }}
           GIT_EMAIL: ${{ secrets.GIT_EMAIL }}
           HUSKY: 0
+        with:
+          command: 'npm run build'
+          target-dir: './dist'
 ```
 
 In this workflow, the action is triggered on every push event that includes a tag. The workflow runs on the latest version of Ubuntu and will not run if the commit message contains `--skip-assets-artifacts`.
 
-The workflow includes steps to checkout the repository, setup Node.js with a specified version and cache configuration, install dependencies using `yarn install`, and finally, build the artifacts using the `widoz/github-artifacts-action@v1` action.
+The workflow includes steps to check out the repository, setup Node.js with a specified version and cache configuration, install dependencies using `yarn install`, and finally, build the artifacts using the `widoz/github-artifacts-action@v1` action.
 
 The `GIT_USER` and `GIT_EMAIL` environment variables are used for the commit and should be stored as secrets in your GitHub repository. The `HUSKY` environment variable is set to `0` to disable Husky during the action run.

--- a/action.yml
+++ b/action.yml
@@ -7,7 +7,5 @@ runs:
 inputs:
   command:
     description: 'Command to execute'
-    default: 'yarn build'
   target-dir:
     description: 'Target directory to upload'
-    default: './build'

--- a/action.yml
+++ b/action.yml
@@ -4,3 +4,10 @@ description: 'Upload assets to GitHub Artifacts'
 runs:
   using: 'node20'
   main: './dist/index.js'
+inputs:
+  command:
+    description: 'Command to execute'
+    default: 'yarn build'
+  target-dir:
+    description: 'Target directory to upload'
+    default: './build'

--- a/dist/index.js
+++ b/dist/index.js
@@ -31583,6 +31583,32 @@ const main_1 = __importDefault(__nccwpck_require__(399));
 
 /***/ }),
 
+/***/ 5778:
+/***/ ((__unused_webpack_module, exports) => {
+
+"use strict";
+
+Object.defineProperty(exports, "__esModule", ({ value: true }));
+exports.Configuration = void 0;
+class Configuration {
+    read;
+    static COMMAND = 'yarn build';
+    static TARGET_DIR = './build';
+    constructor(read) {
+        this.read = read;
+    }
+    get command() {
+        return this.read('command') || Configuration.COMMAND;
+    }
+    get targetDir() {
+        return this.read('target-dir') || Configuration.TARGET_DIR;
+    }
+}
+exports.Configuration = Configuration;
+
+
+/***/ }),
+
 /***/ 6704:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
@@ -31669,10 +31695,12 @@ const artifacts_1 = __nccwpck_require__(1870);
 const tags_1 = __nccwpck_require__(7816);
 const create_git_1 = __nccwpck_require__(6704);
 const temporary_branch_1 = __nccwpck_require__(2786);
+const configuration_1 = __nccwpck_require__(5778);
 async function main() {
+    const configuration = new configuration_1.Configuration(core.getInput.bind(core));
     const git = (0, create_git_1.createGit)();
     const tags = new tags_1.Tags();
-    const artifacts = new artifacts_1.Artifacts(git, tags);
+    const artifacts = new artifacts_1.Artifacts(git, tags, configuration);
     const temporaryBranch = new temporary_branch_1.TemporaryBranch(git);
     Promise.resolve()
         .then(() => temporaryBranch.create())
@@ -31722,11 +31750,11 @@ const exec = __importStar(__nccwpck_require__(1514));
 class Artifacts {
     git;
     tags;
-    static COMMAND = 'yarn build';
-    static TARGET_DIR = './build';
-    constructor(git, tags) {
+    configuration;
+    constructor(git, tags, configuration) {
         this.git = git;
         this.tags = tags;
+        this.configuration = configuration;
     }
     async update() {
         core.startGroup('📦 Creating artifacts');
@@ -31742,7 +31770,7 @@ class Artifacts {
         core.endGroup();
     }
     async compile() {
-        const result = await exec.exec(Artifacts.COMMAND);
+        const result = await exec.exec(this.configuration.command);
         if (result !== 0) {
             throw new Error('Failing to compile artifacts. Process exited with non-zero code.');
         }
@@ -31755,7 +31783,7 @@ class Artifacts {
         await this.tags.move();
     }
     async add() {
-        const result = await exec.exec(`git add -f ${Artifacts.TARGET_DIR}/*`);
+        const result = await exec.exec(`git add -f ${this.configuration.targetDir}/*`);
         if (result !== 0) {
             throw new Error('Failing to git-add the artifacts build. Process exited with non-zero code.');
         }

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -1,0 +1,16 @@
+import type { getInput } from '@actions/core';
+
+export class Configuration {
+  private static readonly COMMAND = 'yarn build';
+  private static readonly TARGET_DIR = './build';
+
+  constructor(private readonly read: typeof getInput) {}
+
+  public get command(): string {
+    return this.read('command') || Configuration.COMMAND;
+  }
+
+  public get targetDir(): string {
+    return this.read('target-dir') || Configuration.TARGET_DIR;
+  }
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -3,11 +3,14 @@ import { Artifacts } from './model/artifacts';
 import { Tags } from './model/tags';
 import { createGit } from './create-git';
 import { TemporaryBranch } from './model/temporary-branch';
+import { Configuration } from './configuration';
 
 async function main(): Promise<void> {
+  const configuration = new Configuration(core.getInput.bind(core));
+
   const git = createGit();
   const tags = new Tags();
-  const artifacts = new Artifacts(git, tags);
+  const artifacts = new Artifacts(git, tags, configuration);
   const temporaryBranch = new TemporaryBranch(git);
 
   Promise.resolve()

--- a/src/model/artifacts.ts
+++ b/src/model/artifacts.ts
@@ -1,15 +1,14 @@
 import type { SimpleGit } from 'simple-git';
-import type { Tags } from './tags';
 import * as core from '@actions/core';
 import * as exec from '@actions/exec';
+import type { Tags } from './tags';
+import type { Configuration } from '../configuration';
 
 export class Artifacts {
-  private static readonly COMMAND = 'yarn build';
-  private static readonly TARGET_DIR = './build';
-
   constructor(
     private readonly git: Readonly<SimpleGit>,
-    private readonly tags: Readonly<Tags>
+    private readonly tags: Readonly<Tags>,
+    private readonly configuration: Readonly<Configuration>
   ) {}
 
   public async update(): Promise<void> {
@@ -28,7 +27,7 @@ export class Artifacts {
   }
 
   private async compile(): Promise<void> {
-    const result = await exec.exec(Artifacts.COMMAND);
+    const result = await exec.exec(this.configuration.command);
     if (result !== 0) {
       throw new Error('Failing to compile artifacts. Process exited with non-zero code.');
     }
@@ -44,7 +43,7 @@ export class Artifacts {
   }
 
   private async add(): Promise<void> {
-    const result = await exec.exec(`git add -f ${Artifacts.TARGET_DIR}/*`);
+    const result = await exec.exec(`git add -f ${this.configuration.targetDir}/*`);
     if (result !== 0) {
       throw new Error('Failing to git-add the artifacts build. Process exited with non-zero code.');
     }


### PR DESCRIPTION
Instead of keeping the command to run and the destination to where upload the artifacts harcoded, we can use the action `inputs` and fallback to the built-in configuration.

These changes introduce a Data Structure called `Configuration`  holding the options coming from the external.
The options are lazy in the sense that, the `Configuration` class has a dependency over the `core.getInput` so that we only call the function when we actually need the value.

The `Configuration` properties are consumed via their getters.